### PR TITLE
 feat: 建立通知資料表與關聯設定（含 schema 與 migration）

### DIFF
--- a/src/drizzle/0000_gray_mole_man.sql
+++ b/src/drizzle/0000_gray_mole_man.sql
@@ -17,16 +17,26 @@ CREATE TABLE "orders" (
 	"updated_at" timestamp DEFAULT now()
 );
 --> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer,
+	"type" text NOT NULL,
+	"message" text NOT NULL,
+	"order_id" text,
+	"read" boolean DEFAULT false,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
 CREATE TABLE "products" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"name" varchar(100) NOT NULL,
 	"description" text NOT NULL,
 	"img" varchar,
 	"price" integer NOT NULL,
-	"status" varchar,
+	"status" varchar DEFAULT 'draft' NOT NULL,
 	"current_stock" integer,
-	"created_at" timestamp,
-	"updated_at" timestamp
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
 );
 --> statement-breakpoint
 CREATE TABLE "users" (
@@ -38,3 +48,5 @@ CREATE TABLE "users" (
 	"updated_at" timestamp DEFAULT now(),
 	CONSTRAINT "users_email_unique" UNIQUE("email")
 );
+--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/drizzle/meta/0000_snapshot.json
+++ b/src/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "20188d76-2ced-4fa2-8f98-11ea607ef2b0",
+  "id": "6bc1bee8-f909-4622-892f-7ef25a07023a",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -116,6 +116,77 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.products": {
       "name": "products",
       "schema": "",
@@ -154,7 +225,8 @@
           "name": "status",
           "type": "varchar",
           "primaryKey": false,
-          "notNull": false
+          "notNull": true,
+          "default": "'draft'"
         },
         "current_stock": {
           "name": "current_stock",
@@ -166,13 +238,15 @@
           "name": "created_at",
           "type": "timestamp",
           "primaryKey": false,
-          "notNull": false
+          "notNull": false,
+          "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
           "type": "timestamp",
           "primaryKey": false,
-          "notNull": false
+          "notNull": false,
+          "default": "now()"
         }
       },
       "indexes": {},

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -5,22 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1748580907616,
-      "tag": "0000_crazy_maestro",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1748333308756,
-      "tag": "0002_square_sabretooth",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1748334689488,
-      "tag": "0003_amusing_mojo",
+      "when": 1748936518574,
+      "tag": "0000_gray_mole_man",
       "breakpoints": true
     }
   ]

--- a/src/models/notificationSchema.js
+++ b/src/models/notificationSchema.js
@@ -1,0 +1,16 @@
+const { pgTable, serial, integer, text, boolean, timestamp } = require("drizzle-orm/pg-core");
+
+const notificationsTable = pgTable("notifications", {
+  id: serial("id").primaryKey(),
+  user_id: integer("user_id").references(() => usersTable.id, { onDelete: "cascade" }),
+  type: text("type").notNull(),
+  message: text("message").notNull(),
+  order_id: text("order_id"),
+  read: boolean("read").default(false),
+  created_at: timestamp("created_at").defaultNow()
+});
+
+
+const { usersTable } = require("./userSchema");
+
+module.exports = { notificationsTable };


### PR DESCRIPTION
📋 內容說明
新增 notificationSchema.js，定義通知欄位與 foreign key（user_id → users.id）
建立 Drizzle migration 檔案 0004_gray_the_spike.sql，同步資料庫結構
欄位包含：
id
user_id（外鍵關聯 users.id，ON DELETE CASCADE）
type
message
order_id
read
created_at

🧪 測試方式
確保 .env 中的 DATABASE_URL 指向正確的 PostgreSQL DB
執行 migration 指令：
npx drizzle-kit push
到資料庫確認 notifications 資料表已建立，並含正確欄位與關聯。
若有 pgAdmin，也可查詢驗證：
SELECT * FROM notifications;

⏭️ 後續規劃
串接通知新增 API（POST /api/notifications）
讓登入使用者可以取得專屬通知列表（GET /api/notifications?userId=）
