### PR TITLE
feat: 建立通知資料表與 ENUM 類型

### DIFF
--- a/src/drizzle/0000_crazy_maestro.sql
+++ b/src/drizzle/0000_crazy_maestro.sql
@@ -43,19 +43,19 @@ CREATE TYPE notification_type AS ENUM (
   'order_created',
   'order_shipped',
   'order_delivered',
-  'promo',
   'account'
 );
 
 CREATE TABLE notifications (
   id SERIAL PRIMARY KEY,
-  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  user_id INTEGER REFERENCES users(id), 
   type notification_type NOT NULL,
   message TEXT NOT NULL,
-  order_id TEXT,
+  order_id INTEGER,                   
   read BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
 
 
 

--- a/src/drizzle/0000_crazy_maestro.sql
+++ b/src/drizzle/0000_crazy_maestro.sql
@@ -38,3 +38,22 @@ CREATE TABLE "users" (
 	"updated_at" timestamp DEFAULT now(),
 	CONSTRAINT "users_email_unique" UNIQUE("email")
 );
+
+CREATE TYPE notification_type AS ENUM (
+  'order_created',
+  'order_shipped',
+  'order_delivered',
+  'promo',
+  'account'
+);
+
+CREATE TABLE notifications (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  type notification_type NOT NULL,
+  message TEXT NOT NULL,
+  order_id TEXT,
+  read BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/src/drizzle/0000_crazy_maestro.sql
+++ b/src/drizzle/0000_crazy_maestro.sql
@@ -57,3 +57,5 @@ CREATE TABLE notifications (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+
+

--- a/src/models/notificationSchema.js
+++ b/src/models/notificationSchema.js
@@ -1,24 +1,32 @@
-const { pgTable, serial, integer, varchar, boolean, timestamp, pgEnum } = require("drizzle-orm/pg-core");
-const { usersTable } = require("./userSchema");
+const {
+  pgTable,
+  serial,
+  integer,
+  varchar,
+  boolean,
+  timestamp,
+  pgEnum,
+} = require('drizzle-orm/pg-core');
+const { usersTable } = require('./userSchema');
 
-const notificationTypeEnum = pgEnum("notification_type", [
-  "order_created",
-  "order_shipped",
-  "order_delivered",
-  "promo",
-  "account"
+const notificationTypeEnum = pgEnum('notification_type', [
+  'order_created',
+  'order_shipped',
+  'order_delivered',
+  'promo',
+  'account',
 ]);
 
-const notificationsTable = pgTable("notifications", {
-  id: serial("id").primaryKey(),
-  user_id: integer("user_id").references(() => usersTable.id, { onDelete: "cascade" }).notNull(),
-  type: notificationTypeEnum("type").notNull(),
-  message: varchar("message", { length: 255 }).notNull(),
-  order_id: integer("order_id"), // 若是非訂單相關通知，這欄可為 null
-  read: boolean("read").default(false),
-  created_at: timestamp("created_at").defaultNow()
+const notificationsTable = pgTable('notifications', {
+  id: serial('id').primaryKey(),
+  user_id: integer('user_id')
+    .references(() => usersTable.id, { onDelete: 'cascade' })
+    .notNull(),
+  type: notificationTypeEnum('type').notNull(),
+  message: varchar('message', { length: 255 }).notNull(),
+  order_id: integer('order_id'), // 若是非訂單相關通知，這欄可為 null
+  read: boolean('read').default(false),
+  created_at: timestamp('created_at').defaultNow(),
 });
 
 module.exports = { notificationsTable, notificationTypeEnum };
-
-

--- a/src/models/notificationSchema.js
+++ b/src/models/notificationSchema.js
@@ -1,32 +1,33 @@
 const {
-  pgTable,
-  serial,
-  integer,
-  varchar,
-  boolean,
-  timestamp,
-  pgEnum,
-} = require('drizzle-orm/pg-core');
-const { usersTable } = require('./userSchema');
-
-const notificationTypeEnum = pgEnum('notification_type', [
-  'order_created',
-  'order_shipped',
-  'order_delivered',
-  'promo',
-  'account',
-]);
-
-const notificationsTable = pgTable('notifications', {
-  id: serial('id').primaryKey(),
-  user_id: integer('user_id')
-    .references(() => usersTable.id, { onDelete: 'cascade' })
-    .notNull(),
-  type: notificationTypeEnum('type').notNull(),
-  message: varchar('message', { length: 255 }).notNull(),
-  order_id: integer('order_id'), // 若是非訂單相關通知，這欄可為 null
-  read: boolean('read').default(false),
-  created_at: timestamp('created_at').defaultNow(),
-});
-
-module.exports = { notificationsTable, notificationTypeEnum };
+    pgTable,
+    serial,
+    integer,
+    varchar,
+    boolean,
+    timestamp,
+    pgEnum,
+  } = require('drizzle-orm/pg-core');
+  const { usersTable } = require('./userSchema');
+  
+  const notificationTypeEnum = pgEnum('notification_type', [
+    'order_created',
+    'order_shipped',
+    'order_delivered',
+    'promo',
+    'account',
+  ]);
+  
+  const notificationsTable = pgTable('notifications', {
+    id: serial('id').primaryKey(),
+    user_id: integer('user_id')
+      .references(() => usersTable.id, { onDelete: 'cascade' })
+      .notNull(),
+    type: notificationTypeEnum('type').notNull(),
+    message: varchar('message', { length: 255 }).notNull(),
+    order_id: integer('order_id'), // 若非訂單相關通知，這裡可為 null
+    read: boolean('read').default(false),
+    created_at: timestamp('created_at').defaultNow(),
+  });
+  
+  module.exports = { notificationsTable, notificationTypeEnum };
+  

--- a/src/models/notificationSchema.js
+++ b/src/models/notificationSchema.js
@@ -1,0 +1,24 @@
+const { pgTable, serial, integer, varchar, boolean, timestamp, pgEnum } = require("drizzle-orm/pg-core");
+const { usersTable } = require("./userSchema");
+
+const notificationTypeEnum = pgEnum("notification_type", [
+  "order_created",
+  "order_shipped",
+  "order_delivered",
+  "promo",
+  "account"
+]);
+
+const notificationsTable = pgTable("notifications", {
+  id: serial("id").primaryKey(),
+  user_id: integer("user_id").references(() => usersTable.id, { onDelete: "cascade" }).notNull(),
+  type: notificationTypeEnum("type").notNull(),
+  message: varchar("message", { length: 255 }).notNull(),
+  order_id: integer("order_id"), // 若是非訂單相關通知，這欄可為 null
+  read: boolean("read").default(false),
+  created_at: timestamp("created_at").defaultNow()
+});
+
+module.exports = { notificationsTable, notificationTypeEnum };
+
+

--- a/src/models/notificationSchema.js
+++ b/src/models/notificationSchema.js
@@ -13,20 +13,19 @@ const notificationTypeEnum = pgEnum('notification_type', [
   'order_created',
   'order_shipped',
   'order_delivered',
-  'promo',
   'account',
 ]);
 
 const notificationsTable = pgTable('notifications', {
   id: serial('id').primaryKey(),
-  user_id: integer('user_id')
-    .references(() => usersTable.id, { onDelete: 'cascade' })
+  userId: integer('user_id')
+    .references(() => usersTable.id)
     .notNull(),
   type: notificationTypeEnum('type').notNull(),
   message: varchar('message', { length: 255 }).notNull(),
-  order_id: integer('order_id'), // 若非訂單相關通知，這裡可為 null
+  orderId: integer('order_id'), // 若非訂單相關通知，這裡可為 null
   read: boolean('read').default(false),
-  created_at: timestamp('created_at').defaultNow(),
+  createdAt: timestamp('created_at').defaultNow(),
 });
 
 module.exports = { notificationsTable, notificationTypeEnum };

--- a/src/models/notificationSchema.js
+++ b/src/models/notificationSchema.js
@@ -1,33 +1,32 @@
 const {
-    pgTable,
-    serial,
-    integer,
-    varchar,
-    boolean,
-    timestamp,
-    pgEnum,
-  } = require('drizzle-orm/pg-core');
-  const { usersTable } = require('./userSchema');
-  
-  const notificationTypeEnum = pgEnum('notification_type', [
-    'order_created',
-    'order_shipped',
-    'order_delivered',
-    'promo',
-    'account',
-  ]);
-  
-  const notificationsTable = pgTable('notifications', {
-    id: serial('id').primaryKey(),
-    user_id: integer('user_id')
-      .references(() => usersTable.id, { onDelete: 'cascade' })
-      .notNull(),
-    type: notificationTypeEnum('type').notNull(),
-    message: varchar('message', { length: 255 }).notNull(),
-    order_id: integer('order_id'), // 若非訂單相關通知，這裡可為 null
-    read: boolean('read').default(false),
-    created_at: timestamp('created_at').defaultNow(),
-  });
-  
-  module.exports = { notificationsTable, notificationTypeEnum };
-  
+  pgTable,
+  serial,
+  integer,
+  varchar,
+  boolean,
+  timestamp,
+  pgEnum,
+} = require('drizzle-orm/pg-core');
+const { usersTable } = require('./userSchema');
+
+const notificationTypeEnum = pgEnum('notification_type', [
+  'order_created',
+  'order_shipped',
+  'order_delivered',
+  'promo',
+  'account',
+]);
+
+const notificationsTable = pgTable('notifications', {
+  id: serial('id').primaryKey(),
+  user_id: integer('user_id')
+    .references(() => usersTable.id, { onDelete: 'cascade' })
+    .notNull(),
+  type: notificationTypeEnum('type').notNull(),
+  message: varchar('message', { length: 255 }).notNull(),
+  order_id: integer('order_id'), // 若非訂單相關通知，這裡可為 null
+  read: boolean('read').default(false),
+  created_at: timestamp('created_at').defaultNow(),
+});
+
+module.exports = { notificationsTable, notificationTypeEnum };


### PR DESCRIPTION
- 新增 notifications 資料表，與 users 表透過 user_id 做關聯（on delete cascade）
- 建立 enum 型別 notification_type，統一通知類型格式
- 支援的通知類型包括：
  - order_created（訂單成立）
  - order_shipped（訂單出貨）
  - order_delivered（訂單到貨）
  - promo（優惠訊息）
  - account（帳戶通知）
- 欄位包含 message、order_id（非訂單通知可為 null）、read（預設為 false）、created_at（預設 now）

🔧 後端測試流程

切換到此分支
git checkout feat/notification-schema
安裝必要套件
npm install
建立資料表與欄位
npx drizzle-kit push
開啟 pgAdmin，確認資料表已正確建立（應有 notifications 與 enum notification_type）

Closes #8 