### PR TITLE
feat: 新增庫存記錄 schema 並修改 productSchema 狀態欄位為 ENUM

### DIFF
--- a/src/models/productSchema.js
+++ b/src/models/productSchema.js
@@ -1,5 +1,6 @@
 const {
   pgTable,
+  pgEnum,
   serial,
   varchar,
   integer,
@@ -8,6 +9,7 @@ const {
   check,
 } = require('drizzle-orm/pg-core');
 const { sql } = require('drizzle-orm');
+const statusEnum = pgEnum('status', ['draft', 'active', 'archived']);
 
 const productsTable = pgTable(
   'products',
@@ -27,4 +29,4 @@ const productsTable = pgTable(
   (table) => [check('price_check', sql`${table.price} >= 0`)]
 );
 
-module.exports = { productsTable };
+module.exports = { productsTable, statusEnum };

--- a/src/models/stockLogSchema.js
+++ b/src/models/stockLogSchema.js
@@ -1,0 +1,27 @@
+const { pgTable, pgEnum, serial, integer, varchar, timestamp } = require('drizzle-orm/pg-core');
+const { productsTable } = require('./productSchema');
+
+const stockReasonEnum = pgEnum('stock_reason', [
+  'stock_in',
+  'stock_out',
+  'adjustment',
+  'initial',
+  'return',
+]);
+
+const stockLogsTable = pgTable('stock_logs', {
+  id: serial('id').primaryKey().notNull(),
+  productId: integer('product_id')
+    .notNull()
+    .references(() => productsTable.id),
+  amountBefore: integer('amount_before').notNull(),
+  amountAfter: integer('amount_after').notNull(),
+  amountChange: integer('amount_change').notNull(),
+  reason: stockReasonEnum('reason').default('adjustment'),
+  role: varchar('role', { length: 100 }),
+  createdAt: timestamp('created_at').defaultNow(),
+});
+
+module.exports = {
+  stockLogsTable,
+};


### PR DESCRIPTION
### 變更內容
- 新增庫存歷史 Table `stockLogSchema` ，修改原因資料型態為 ENUM
- 修改 `productSchema` status 欄位的資料型態為 ENUM

### 修改原因
- 庫存歷史要用在後台庫存列表，點擊單一列商品，會跳轉顯示該商品過去的庫存修改歷史列表
- 一個欄位的資料如果只能填入特定幾個值，適合使用 ENUM 以免存入錯誤的資料 

- Issue: #14 

