### PR TITLE
feat: 綠界訂單付款成功後，同時更新內部訂單資料庫狀態與金額

### DIFF
--- a/drizzle.config.js
+++ b/drizzle.config.js
@@ -8,7 +8,7 @@ console.log('📦 DATABASE_URL:', process.env.DATABASE_URL); // debug 用
 
 module.exports = defineConfig({
   out: './src/drizzle',
-  schema: './src/models/**/*.js', // 在models底下的所有 ***.js
+  schema: './src/models/*Schema.js', // 在models底下的所有 ***.js
   dialect: 'postgresql',
   dbCredentials: {
     url: process.env.DATABASE_URL,

--- a/src/controllers/ecpayController.js
+++ b/src/controllers/ecpayController.js
@@ -3,8 +3,17 @@ const ecpayConfig = require('../configs/ecpayConfig');
 const ecpay_payment = require('ecpay_aio_nodejs');
 const db = require('../configs/db');
 const { ecpayOrdersTable } = require('../models/ecpaySchema');
+const { ordersTable } = require('../models/orderSchema');
 const { eq } = require('drizzle-orm');
-const { nanoid } = require('nanoid');
+const { customAlphabet } = require('nanoid');
+const nanoid = customAlphabet('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', 6);
+
+const generateOrderId = () => {
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+  return `WP${dateStr}${nanoid()}`;
+};
+
 const options = {
   OperationMode: 'Test',
   MercProfile: {
@@ -16,9 +25,10 @@ const options = {
   IsProjectContractor: false,
 };
 const create = new ecpay_payment(options);
+
 exports.createOrder = async (req, res) => {
   const { TotalAmount, TradeDesc, ItemName } = req.body;
-  const MerchantTradeNo = Date.now().toString() + nanoid(6);
+  const MerchantTradeNo = generateOrderId();
   const MerchantTradeDate = new Date()
     .toLocaleString('zh-TW', {
       year: 'numeric',
@@ -69,8 +79,16 @@ exports.createOrder = async (req, res) => {
 
 exports.handleReturn = async (req, res) => {
   console.log('綠界回傳資料 (POST):', req.body);
-  const { CheckMacValue, MerchantTradeNo, RtnCode, RtnMsg, PaymentDate, SimulatePaid, TradeNo } =
-    req.body;
+  const {
+    CheckMacValue,
+    MerchantTradeNo,
+    RtnCode,
+    RtnMsg,
+    PaymentDate,
+    SimulatePaid,
+    TradeNo,
+    totalAmount,
+  } = req.body;
   const data = { ...req.body };
   delete data.CheckMacValue;
 
@@ -107,6 +125,18 @@ exports.handleReturn = async (req, res) => {
         .where(eq(ecpayOrdersTable.merchantTradeNo, MerchantTradeNo));
 
       console.log(`資料庫訂單 ${MerchantTradeNo} 狀態已更新為 ${newTradeStatus}`);
+
+      const [updatedOrder] = await db
+        .update(ordersTable)
+        .set({
+          status: 'paid',
+          totalPrice: Number(totalAmount),
+          updatedAt: new Date(),
+        })
+        .where(eq(ordersTable.orderNumber, MerchantTradeNo))
+        .returning();
+      console.log('訂單已成功更新：', updatedOrder);
+
       res.send('1|OK'); // 告知綠界已成功接收
     } catch (error) {
       console.error('更新訂單狀態時發生錯誤:', error);

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -2,6 +2,31 @@ require('express');
 const db = require('../configs/db');
 const { ordersTable } = require('../models/orderSchema');
 const { eq } = require('drizzle-orm');
+const { nanoid } = require('nanoid');
+
+const generateOrderId = () => {
+  const now = new Date();
+  const yyyyMMdd = now.toISOString().slice(0, 10).replace(/-/g, ''); // '20250609'
+  const randomPart = nanoid(6);
+  return `OD-${yyyyMMdd}-${randomPart}`;
+};
+
+const createOrder = async (req, res) => {
+  try {
+    const [insertedOrder] = await db
+      .insert(ordersTable)
+      .values({
+        orderNumber: generateOrderId(),
+        ...req.body,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning();
+    res.status(201).json(insertedOrder);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
 
 const getOrderById = async (req, res) => {
   const id = Number(req.params.id);
@@ -20,18 +45,13 @@ const getOrderById = async (req, res) => {
 
 const updateOrder = async (req, res) => {
   const id = Number(req.params.id);
-  const { recipientName, recipientPhone, shippingAddress, status } = req.body;
-  if (!recipientName || !recipientPhone || !shippingAddress || !status) {
-    return res.status(400).json({ error: '缺少必要欄位' });
-  }
+  if (isNaN(id)) return res.status(400).json({ error: '無效的ID' });
+
   try {
     const [insertedOrder] = await db
       .update(ordersTable)
       .set({
-        recipientName,
-        recipientPhone,
-        shippingAddress,
-        status,
+        ...req.body,
         updatedAt: new Date(),
       })
       .where(eq(ordersTable.id, id))
@@ -44,6 +64,8 @@ const updateOrder = async (req, res) => {
 
 const softDeleteOrder = async (req, res) => {
   const id = Number(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ error: '無效的ID' });
+
   try {
     await db.update(ordersTable).set({ isDeleted: true }).where(eq(ordersTable.id, id));
     res.json({ message: '訂單已軟刪除' });
@@ -52,4 +74,4 @@ const softDeleteOrder = async (req, res) => {
   }
 };
 
-module.exports = { getOrderById, updateOrder, softDeleteOrder };
+module.exports = { createOrder, getOrderById, updateOrder, softDeleteOrder };

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -2,21 +2,12 @@ require('express');
 const db = require('../configs/db');
 const { ordersTable } = require('../models/orderSchema');
 const { eq } = require('drizzle-orm');
-const { nanoid } = require('nanoid');
-
-const generateOrderId = () => {
-  const now = new Date();
-  const yyyyMMdd = now.toISOString().slice(0, 10).replace(/-/g, ''); // '20250609'
-  const randomPart = nanoid(6);
-  return `OD-${yyyyMMdd}-${randomPart}`;
-};
 
 const createOrder = async (req, res) => {
   try {
     const [insertedOrder] = await db
       .insert(ordersTable)
       .values({
-        orderNumber: generateOrderId(),
         ...req.body,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -67,8 +58,12 @@ const softDeleteOrder = async (req, res) => {
   if (isNaN(id)) return res.status(400).json({ error: '無效的ID' });
 
   try {
-    await db.update(ordersTable).set({ isDeleted: true }).where(eq(ordersTable.id, id));
-    res.json({ message: '訂單已軟刪除' });
+    const [deleted] = await db
+      .update(ordersTable)
+      .set({ isDeleted: true })
+      .where(eq(ordersTable.id, id))
+      .returning();
+    res.status(201).json([deleted]);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -155,7 +155,7 @@ const deleteProduct = async (req, res) => {
   if (isNaN(id)) return res.status(400).json({ error: '無效的ID' });
 
   try {
-    const deleted = await db
+    const [deleted] = await db
       .update(productsTable)
       .set({ isDeleted: true })
       .where(eq(productsTable.id, id))
@@ -165,7 +165,7 @@ const deleteProduct = async (req, res) => {
       return res.status(404).json({ error: '查無此商品' });
     }
 
-    res.json({ message: '商品已刪除' });
+    res.statsu(201).json(deleted);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/src/models/orderSchema.js
+++ b/src/models/orderSchema.js
@@ -10,6 +10,7 @@ const {
 const { usersTable } = require('./userSchema');
 
 const orderStatusEnum = pgEnum('order_status', [
+  'pending',
   'paid',
   'cancelled',
   'refunded',
@@ -27,7 +28,7 @@ const ordersTable = pgTable('orders', {
   shippingAddress: varchar('shipping_address', { length: 255 }).notNull(),
   totalPrice: integer('total_price').notNull(),
   quantity: integer('quantity').notNull(),
-  status: orderStatusEnum('status').default('paid').notNull(),
+  status: orderStatusEnum('status').default('pending').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
   isDeleted: boolean('is_deleted').default(false),

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -1,15 +1,24 @@
 const express = require('express');
 const router = express.Router();
-const { updateOrder, softDeleteOrder, getOrderById } = require('../controllers/orderController');
 
+const {
+  createOrder,
+  updateOrder,
+  softDeleteOrder,
+  getOrderById,
+} = require('../controllers/orderController');
+
+const isAdmin = require('../middleware/isAdmin');
+const validate = require('../middleware/validate');
+
+const { orderSchema } = require('../validators/orderValidator');
 // for users
-// router.get('/orders', getAllOrders);
 router.get('/orders/:id', getOrderById);
 
 // for admin
-// router.get('/admin/orders', getAllOrders);
 router.get('/admin/orders/:id', getOrderById);
 router.put('/admin/orders/:id', updateOrder);
+router.post('/admin/orders', isAdmin, validate(orderSchema), createOrder);
 router.delete('/admin/orders/:id', softDeleteOrder);
 
 module.exports = router;

--- a/src/validators/orderValidator.js
+++ b/src/validators/orderValidator.js
@@ -1,0 +1,24 @@
+const { z } = require('zod');
+
+const statusValues = [
+  'pending',
+  'paid',
+  'cancelled',
+  'refunded',
+  'shipped',
+  'delivered',
+  'returned',
+];
+
+const orderSchema = z.object({
+  orderNumber: z.string().min(1),
+  userId: z.number().min(1),
+  recipientName: z.string().min(1),
+  recipientPhone: z.string().min(1),
+  shippingAddress: z.string().min(1),
+  totalPrice: z.number().min(0),
+  quantity: z.number().min(0),
+  status: z.enum(statusValues),
+});
+
+module.exports = { orderSchema };


### PR DESCRIPTION
### 變更內容
- 新增 updateOrder 邏輯在 `ecpayController`
- `orderSchema` status 多一個 `pending`
- 新增 createOrder
- 修改綠界訂單編號生成方式，與內部訂單編號生成相同

### 修改原因
- 原本內部訂單想要在綠界訂單狀態確定 paid 才 createOrder，但這樣做的話 order 其餘欄位也要經由 ecpayController 傳送，造成金流跟訂單職責混在一起

- **金額**與**狀態**最好在確認付款成功後，從綠界資料庫這邊抓，比從購物車抓更準確安全

- 改成綠界訂單成立時就同時 createOrder，讓 order 一開始是 pending 狀態，確認綠界付款成功後，同時處理狀態更新為 paid 並傳送訂單金額

- 其餘訂單欄位從購物車前端傳送

### 驗證方式
- 前端還沒寫 API 抓其他訂單資料欄位，等我寫完再一起測 createOrder！
- 需要 ngrok