### PR TITLE
Feat:新增登入時判斷使用者的角色

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -54,19 +54,19 @@ const login = async (req, res) => {
   try {
     const user = await db.select().from(usersTable).where(eq(usersTable.email, email)).limit(1);
     if (user.length === 0) {
-      return res.status(401).json({ error: '帳號或密碼錯誤' });
+      return res.status(404).json({ error: 'Email未註冊' });
     }
 
     const isPasswordValid = await bcrypt.compare(password, user[0].password);
     if (!isPasswordValid) {
-      return res.status(401).json({ error: '帳號或密碼錯誤' });
+      return res.status(401).json({ error: '密碼錯誤' });
     }
 
-    const token = jwt.sign({ id: user[0].id, email: user[0].email }, process.env.JWT_SECRET, {
+    const token = jwt.sign({ id: user[0].id, email: user[0].email, role: user[0].role }, process.env.JWT_SECRET, {
       expiresIn: '1d',
     });
 
-    res.status(200).json({ message: '登入成功', token });
+    res.status(200).json({ message: '登入成功', token, role: user[0].role});
   } catch (err) {
     console.error('登入失敗', err);
     res.status(500).json({ error: '伺服器錯誤' });

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -62,11 +62,15 @@ const login = async (req, res) => {
       return res.status(401).json({ error: '密碼錯誤' });
     }
 
-    const token = jwt.sign({ id: user[0].id, email: user[0].email, role: user[0].role }, process.env.JWT_SECRET, {
-      expiresIn: '1d',
-    });
+    const token = jwt.sign(
+      { id: user[0].id, email: user[0].email, role: user[0].role },
+      process.env.JWT_SECRET,
+      {
+        expiresIn: '1d',
+      }
+    );
 
-    res.status(200).json({ message: '登入成功', token, role: user[0].role});
+    res.status(200).json({ message: '登入成功', token, role: user[0].role });
   } catch (err) {
     console.error('登入失敗', err);
     res.status(500).json({ error: '伺服器錯誤' });

--- a/src/models/userSchema.js
+++ b/src/models/userSchema.js
@@ -5,6 +5,7 @@ const usersTable = pgTable('users', {
   username: varchar('username', { length: 50 }).notNull(),
   email: varchar('email', { length: 100 }).notNull().unique(),
   password: varchar('password', { length: 255 }).notNull(),
+  role: roleEnum('role').default('user'),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 });


### PR DESCRIPTION
### 變更內容
新增登入驗證：檢查角色欄位
修改登入失敗回傳值，改成res(404):email未註冊 

### 驗證方式
需等PR25合併後才能測試
需至資料庫將role欄位改成admin(預設是user)
改完後可至前端登入測試，若為admin則跳轉至後台頁面

### 備註
**需等PR25合併完才能合併！！**

**相關資源**
Close:#https://github.com/wanpai-app/backend/issues/40

