### PR TITLE
（請不要rebase這個分支）feat: 執行 GET /orders/:id API 

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,6 @@ app.use(cors());
 app.use('/api', productRoutes);
 app.use('/api', require('./src/routes/orderRoutes'));
 
-
-
 //綠界使用的
 app.use('/api', ecpayRoutes);
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 app.use('/api', productRoutes);
+app.use('/api', require('./src/routes/orderRoutes'));
+
+
 
 //綠界使用的
 app.use('/api', ecpayRoutes);

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ app.use('/api', require('./src/routes/orderRoutes'));
 
 
 
+
 //綠界使用的
 app.use('/api', ecpayRoutes);
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ app.use('/api', require('./src/routes/orderRoutes'));
 
 
 
-
 //綠界使用的
 app.use('/api', ecpayRoutes);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "express": "^5.1.0",
         "faker": "^6.6.6",
         "jsonwebtoken": "^9.0.0",
-        "nanoid": "^3.3.4",
         "minimist": "^1.2.8",
+        "nanoid": "^3.3.4",
         "nodemon": "^3.1.10",
         "pg": "^8.16.0",
         "zod": "^3.25.56"
@@ -2839,6 +2839,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@faker-js/faker": "^9.8.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "drizzle-orm": "^0.44.2",
         "ecpay_aio_nodejs": "^1.2.2",
         "express": "^5.1.0",
+        "faker": "^6.6.6",
         "jsonwebtoken": "^9.0.0",
         "nanoid": "^3.3.4",
+        "minimist": "^1.2.8",
         "nodemon": "^3.1.10",
         "pg": "^8.16.0",
         "zod": "^3.25.56"
@@ -1052,6 +1055,22 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.8.0.tgz",
+      "integrity": "sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2154,6 +2173,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/faker": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
+      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2814,6 +2839,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2841,15 +2841,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,17 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@faker-js/faker": "^9.8.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.44.2",
     "ecpay_aio_nodejs": "^1.2.2",
     "express": "^5.1.0",
+    "faker": "^6.6.6",
     "jsonwebtoken": "^9.0.0",
     "nanoid": "^3.3.4",
+    "minimist": "^1.2.8",
     "nodemon": "^3.1.10",
     "pg": "^8.16.0",
     "zod": "^3.25.56"

--- a/scripts/seed-orders.js
+++ b/scripts/seed-orders.js
@@ -1,0 +1,38 @@
+
+
+const db = require('../src/configs/db'); 
+const { eq } = require('drizzle-orm');
+const { ordersTable } = require('../src/models/orderSchema');
+const { usersTable }  = require('../src/models/userSchema');
+
+async function insertFakeOrder() {
+  try {
+    const user = await db.select().from(usersTable).where(eq(usersTable.id, 1));
+
+    if (user.length === 0) {
+      console.log(' 找不到 userId = 1 的使用者，請先執行 seed-users.js');
+      process.exit(1);
+    }
+
+    // 插入假訂單
+    await db.insert(ordersTable).values({
+      orderNumber: 'A88888888',
+      userId: 1, // 連到剛剛那位使用者
+      recipientName: '雨雨',
+      recipientPhone: '0912345678',
+      shippingAddress: '台北市夢想路 1 號',
+      totalPrice: 999,
+      quantity: 2,
+      status: 'paid',
+    });
+
+    console.log(' 假訂單插入成功！可以開始測試 API 囉～');
+    process.exit(0);
+  } catch (err) {
+    console.error(' 插入訂單失敗：', err);
+    process.exit(1);
+  }
+}
+
+insertFakeOrder(); 
+

--- a/scripts/seed-orders.js
+++ b/scripts/seed-orders.js
@@ -18,7 +18,7 @@ async function insertFakeOrder() {
     await db.insert(ordersTable).values({
       orderNumber: 'A88888888',
       userId: 1, // 連到剛剛那位使用者
-      recipientName: '雨雨',
+      recipientName: '布魯托',
       recipientPhone: '0912345678',
       shippingAddress: '台北市夢想路 1 號',
       totalPrice: 999,

--- a/scripts/seed-orders.js
+++ b/scripts/seed-orders.js
@@ -1,38 +1,67 @@
-
-
-const db = require('../src/configs/db'); 
+/**
+ * 🧪 [測試用] seed-orders.js
+ *
+ * 這份檔案用來產生假訂單資料，方便本地測試 API。
+ *
+ * 使用方式：
+ *   node scripts/seed-orders.js
+ *   node scripts/seed-orders.js --count=10  // 指定筆數
+ */
+const db = require('../src/configs/db');
 const { eq } = require('drizzle-orm');
-const { ordersTable } = require('../src/models/orderSchema');
-const { usersTable }  = require('../src/models/userSchema');
+const { ordersTable, orderStatusEnum } = require('../src/models/orderSchema');
+const { usersTable } = require('../src/models/userSchema');
+const { faker } = require('@faker-js/faker');
+const minimist = require('minimist');
 
-async function insertFakeOrder() {
+const args = minimist(process.argv.slice(2));
+const count = args.count || 10;
+
+function generateOrderNumber(index) {
+  const today = new Date();
+  const yyyyMMdd = today.toISOString().slice(0, 10).replace(/-/g, '');
+  const serial = String(index + 1).padStart(4, '0');
+  return `OD-${yyyyMMdd}-${serial}`;
+}
+
+const statusOptions = [
+  'paid',
+  'cancelled',
+  'refunded',
+  'shipped',
+  'delivered',
+  'returned',
+];
+
+async function insertFakeOrders() {
   try {
-    const user = await db.select().from(usersTable).where(eq(usersTable.id, 1));
-
-    if (user.length === 0) {
-      console.log(' 找不到 userId = 1 的使用者，請先執行 seed-users.js');
-      process.exit(1);
+    const users = await db.select().from(usersTable);
+    if (users.length === 0) {
+      console.log(' 沒有使用者資料，請先執行 seed-users.js');
+      return;
     }
 
-    // 插入假訂單
-    await db.insert(ordersTable).values({
-      orderNumber: 'A88888888',
-      userId: 1, // 連到剛剛那位使用者
-      recipientName: '布魯托',
-      recipientPhone: '0912345678',
-      shippingAddress: '台北市夢想路 1 號',
-      totalPrice: 999,
-      quantity: 2,
-      status: 'paid',
+    const orders = Array.from({ length: count }, (_, index) => {
+      const user = faker.helpers.arrayElement(users);
+      return {
+        orderNumber: generateOrderNumber(index),
+        userId: user.id,
+        recipientName: faker.person.fullName(),
+        recipientPhone: faker.phone.number('09########'),
+        shippingAddress: faker.location.streetAddress({ useFullAddress: true }),
+        totalPrice: faker.number.int({ min: 500, max: 5000 }),
+        quantity: faker.number.int({ min: 1, max: 5 }),
+        status: faker.helpers.arrayElement(statusOptions),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
     });
 
-    console.log(' 假訂單插入成功！可以開始測試 API 囉～');
-    process.exit(0);
+    await db.insert(ordersTable).values(orders);
+    console.log(` 成功插入 ${count} 筆訂單資料！`);
   } catch (err) {
     console.error(' 插入訂單失敗：', err);
-    process.exit(1);
   }
 }
 
-insertFakeOrder(); 
-
+insertFakeOrders();

--- a/scripts/seed-orders.js
+++ b/scripts/seed-orders.js
@@ -23,14 +23,7 @@ function generateOrderNumber(index) {
   return `OD-${yyyyMMdd}-${serial}`;
 }
 
-const statusOptions = [
-  'paid',
-  'cancelled',
-  'refunded',
-  'shipped',
-  'delivered',
-  'returned',
-];
+const statusOptions = ['paid', 'cancelled', 'refunded', 'shipped', 'delivered', 'returned'];
 
 async function insertFakeOrders() {
   try {
@@ -56,16 +49,15 @@ async function insertFakeOrders() {
       };
     });
 
-   for (let i = 0; i < orders.length; i++) {
-     try {
-       await db.insert(ordersTable).values(orders[i]);
-     } catch (e) {
-       console.error(` 第 ${i + 1} 筆插入失敗`, orders[i]);
-       throw e; 
-     }
-   }
-   console.log(` 成功插入 ${count} 筆訂單資料！`);
-
+    for (let i = 0; i < orders.length; i++) {
+      try {
+        await db.insert(ordersTable).values(orders[i]);
+      } catch (e) {
+        console.error(` 第 ${i + 1} 筆插入失敗`, orders[i]);
+        throw e;
+      }
+    }
+    console.log(` 成功插入 ${count} 筆訂單資料！`);
   } catch (err) {
     console.error(' 插入訂單失敗：', err);
   }

--- a/scripts/seed-orders.js
+++ b/scripts/seed-orders.js
@@ -8,8 +8,7 @@
  *   node scripts/seed-orders.js --count=10  // 指定筆數
  */
 const db = require('../src/configs/db');
-const { eq } = require('drizzle-orm');
-const { ordersTable, orderStatusEnum } = require('../src/models/orderSchema');
+const { ordersTable } = require('../src/models/orderSchema');
 const { usersTable } = require('../src/models/userSchema');
 const { faker } = require('@faker-js/faker');
 const minimist = require('minimist');
@@ -47,7 +46,7 @@ async function insertFakeOrders() {
         orderNumber: generateOrderNumber(index),
         userId: user.id,
         recipientName: faker.person.fullName(),
-        recipientPhone: faker.phone.number('09########'),
+        recipientPhone: faker.phone.number().slice(0, 20),
         shippingAddress: faker.location.streetAddress({ useFullAddress: true }),
         totalPrice: faker.number.int({ min: 500, max: 5000 }),
         quantity: faker.number.int({ min: 1, max: 5 }),
@@ -57,8 +56,16 @@ async function insertFakeOrders() {
       };
     });
 
-    await db.insert(ordersTable).values(orders);
-    console.log(` 成功插入 ${count} 筆訂單資料！`);
+   for (let i = 0; i < orders.length; i++) {
+     try {
+       await db.insert(ordersTable).values(orders[i]);
+     } catch (e) {
+       console.error(` 第 ${i + 1} 筆插入失敗`, orders[i]);
+       throw e; 
+     }
+   }
+   console.log(` 成功插入 ${count} 筆訂單資料！`);
+
   } catch (err) {
     console.error(' 插入訂單失敗：', err);
   }

--- a/scripts/seed-users.js
+++ b/scripts/seed-users.js
@@ -15,11 +15,11 @@ async function insertFakeUser() {
     }
 
     await db.insert(usersTable).values({
-      id: 1, // 固定 ID 方便其他 seed 連接
+      id: 1, 
       username: 'yuyu',
       email: 'yuyu@example.com',
       password: '123456', // 測試用
-      role: 'user', // 如果有 enum 記得 role 要合法
+      role: 'user', 
     });
 
     console.log('✅ 成功新增一筆假使用者');

--- a/scripts/seed-users.js
+++ b/scripts/seed-users.js
@@ -1,0 +1,33 @@
+// scripts/seed-users.js
+
+const  db  = require('../src/configs/db');
+const { eq } = require('drizzle-orm'); 
+const { usersTable } = require('../src/models/userSchema');
+
+async function insertFakeUser() {
+  try {
+    const exists = await db.select().from(usersTable).where(eq(usersTable.id, 1));
+
+
+    if (exists.length > 0) {
+      console.log(' 已有 id=1 的使用者，略過新增');
+      process.exit(0);
+    }
+
+    await db.insert(usersTable).values({
+      id: 1, // 固定 ID 方便其他 seed 連接
+      username: 'yuyu',
+      email: 'yuyu@example.com',
+      password: '123456', // 測試用
+      role: 'user', // 如果有 enum 記得 role 要合法
+    });
+
+    console.log('✅ 成功新增一筆假使用者');
+    process.exit(0);
+  } catch (err) {
+    console.error('❌ 新增使用者失敗：', err);
+    process.exit(1);
+  }
+}
+
+insertFakeUser();

--- a/scripts/seed-users.js
+++ b/scripts/seed-users.js
@@ -1,4 +1,16 @@
-// scripts/seed-users.js
+/**
+ * 🧪 [測試用] seed-users.js
+ *
+ * 這份檔案用來產生假使用者資料，方便本地測試會員／訂單相關功能。
+ *
+ * 注意：
+ * - 請勿上傳真實密碼，此處皆為測試資料。
+ * - 請在資料庫清空或切換環境後再執行，避免資料重複。
+ *
+ * 使用方式：
+ *   node scripts/seed-users.js
+ */
+
 
 const  db  = require('../src/configs/db');
 const { eq } = require('drizzle-orm'); 
@@ -22,10 +34,10 @@ async function insertFakeUser() {
       role: 'user', 
     });
 
-    console.log('✅ 成功新增一筆假使用者');
+    console.log(' 成功新增一筆假使用者');
     process.exit(0);
   } catch (err) {
-    console.error('❌ 新增使用者失敗：', err);
+    console.error(' 新增使用者失敗：', err);
     process.exit(1);
   }
 }

--- a/scripts/seed-users.js
+++ b/scripts/seed-users.js
@@ -8,30 +8,39 @@
  * - 請在資料庫清空或切換環境後再執行，避免資料重複。
  *
  * 使用方式：
- *   node scripts/seed-users.js
+ *   node scripts/seed-users.js  # ➜ 如果資料表裡已經有 id=1，就會跳過
+ *   node scripts/seed-users.js --reset # ➜ 清空 orders 和 users，再新增
  */
 
-
-const  db  = require('../src/configs/db');
-const { eq } = require('drizzle-orm'); 
+const db = require('../src/configs/db');
+const { eq } = require('drizzle-orm');
 const { usersTable } = require('../src/models/userSchema');
+const minimist = require('minimist');
+const { sql } = require('drizzle-orm');
+
+const args = minimist(process.argv.slice(2));
 
 async function insertFakeUser() {
   try {
+    if (args.reset) {
+      await db.execute(sql`DELETE FROM orders`);
+      await db.execute(sql`DELETE FROM users`);
+      console.log('🧹 已清空 orders 和 users 資料表');
+    }
+
     const exists = await db.select().from(usersTable).where(eq(usersTable.id, 1));
 
-
     if (exists.length > 0) {
-      console.log(' 已有 id=1 的使用者，略過新增');
+      console.log('已有 id=1 的使用者，略過新增');
       process.exit(0);
     }
 
     await db.insert(usersTable).values({
-      id: 1, 
+      id: 1,
       username: 'yuyu',
       email: 'yuyu@example.com',
-      password: '123456', // 測試用
-      role: 'user', 
+      password: '123456', // 測試用密碼
+      role: 'user',
     });
 
     console.log(' 成功新增一筆假使用者');

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -38,3 +38,22 @@ const softDeleteOrder = async (req, res) => {
 };
 
 module.exports = { updateOrder, softDeleteOrder };
+
+const getOrderById = async (req, res) => {
+  const id = parseInt(req.params.id);
+
+  try {
+    const order = await db.select().from(ordersTable).where(eq(ordersTable.id, id));
+
+    if (!order || order.length === 0) {
+      return res.status(404).json({ message: '找不到訂單' });
+    }
+
+    res.json(order[0]);
+  } catch (error) {
+    console.error('無法取得訂單：', error);
+    res.status(500).json({ message: '伺服器錯誤' });
+  }
+};
+
+module.exports = { getOrderById };

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -3,6 +3,21 @@ const db = require('../configs/db');
 const { ordersTable } = require('../models/orderSchema');
 const { eq } = require('drizzle-orm');
 
+const getOrderById = async (req, res) => {
+  const id = Number(req.params.id);
+  try {
+    const [order] = await db.select().from(ordersTable).where(eq(ordersTable.id, id));
+
+    if (!order) {
+      return res.status(404).json({ message: '找不到該訂單' });
+    }
+
+    res.json(order);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
 const updateOrder = async (req, res) => {
   const id = Number(req.params.id);
   const { recipientName, recipientPhone, shippingAddress, status } = req.body;
@@ -37,23 +52,4 @@ const softDeleteOrder = async (req, res) => {
   }
 };
 
-module.exports = { updateOrder, softDeleteOrder };
-
-const getOrderById = async (req, res) => {
-  const id = parseInt(req.params.id);
-
-  try {
-    const order = await db.select().from(ordersTable).where(eq(ordersTable.id, id));
-
-    if (!order || order.length === 0) {
-      return res.status(404).json({ message: '找不到訂單' });
-    }
-
-    res.json(order[0]);
-  } catch (error) {
-    console.error('無法取得訂單：', error);
-    res.status(500).json({ message: '伺服器錯誤' });
-  }
-};
-
-module.exports = { getOrderById };
+module.exports = { getOrderById, updateOrder, softDeleteOrder };

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -11,8 +11,5 @@ router.get('/orders/:id', getOrderById);
 router.get('/admin/orders/:id', getOrderById);
 router.put('/admin/orders/:id', updateOrder);
 router.delete('/admin/orders/:id', softDeleteOrder);
-const { getOrderById } = require('../controllers/orderController');
-
-router.get('/orders/:id', getOrderById);
 
 module.exports = router;

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -1,14 +1,14 @@
 const express = require('express');
 const router = express.Router();
-const { updateOrder, softDeleteOrder } = require('../controllers/orderController');
+const { updateOrder, softDeleteOrder, getOrderById } = require('../controllers/orderController');
 
 // for users
 // router.get('/orders', getAllOrders);
-// router.get('/orders/:id', getOrderById);
+router.get('/orders/:id', getOrderById);
 
 // for admin
 // router.get('/admin/orders', getAllOrders);
-// router.get('/admin/orders/:id', getOrderById);
+router.get('/admin/orders/:id', getOrderById);
 router.put('/admin/orders/:id', updateOrder);
 router.delete('/admin/orders/:id', softDeleteOrder);
 const { getOrderById } = require('../controllers/orderController');

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -11,5 +11,8 @@ const { updateOrder, softDeleteOrder } = require('../controllers/orderController
 // router.get('/admin/orders/:id', getOrderById);
 router.put('/admin/orders/:id', updateOrder);
 router.delete('/admin/orders/:id', softDeleteOrder);
+const { getOrderById } = require('../controllers/orderController');
+
+router.get('/orders/:id', getOrderById);
 
 module.exports = router;


### PR DESCRIPTION
## 功能
- 完成 `/api/orders/:id` API，根據訂單 id 回傳訂單資訊
- 回傳欄位包含：訂單編號、收件人姓名、電話、地址、金額、狀態、建立時間等
- 撰寫 seed script `scripts/seed-orders.js` 產生假訂單資料，方便測試 API
- 使用 pgAdmin 確認資料成功寫入資料庫
- 使用 Postman 測試 API 回傳格式是否正確

## 如何測試
1. 先執行以下指令新增 10 筆假訂單資料：
   `node scripts/seed-orders.js --count=10`

2. 查詢資料庫確認訂單 id（使用 pgAdmin → 右鍵點選 orders 表 → Query Tool)：
    SELECT * FROM orders;

3. 在 Postman 測試：
    GET   http://localhost:3001/api/orders/27 (將 27 替換成你查到的訂單 ID)

   可依需求搭配 --reset 重建資料（⚠️ 會清空 orders 表）：
   node scripts/seed-orders.js --reset

   seed script 不會自動清空資料，請自行確認不會與現有資料衝突

##  建議清空資料重建
若你的資料庫中已經存在 `orders` 表，但欄位結構與目前專案不一致，請執行以下步驟清空並重新建立：

1. 刪除 orders 表  
2. 重新執行 migrate → `npm run migrate`
3. 執行 seed 建立假資料 → `node scripts/seed-orders.js`

### 注意：此操作會清空 `orders` 資料，請確認目前沒有重要資料再執行。

Closes #27