### PR TITLE
Feat: 增加標籤api 

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,18 +8,20 @@ const ecpayRoutes = require('./src/routes/ecpayRoutes');
 const orderRoutes = require('./src/routes/orderRoutes');
 const notificationRoutes = require('./src/routes/notificationRoutes');
 
+const tagRoutes = require('./src/routes/tagsRoutes');
 const app = express();
 
 app.use(express.json());
 app.use(cors());
 app.use('/api', productRoutes);
 
-//綠界使用的
 app.use('/api', ecpayRoutes);
 
 app.use('/api/users', userRoutes);
 app.use('/api', orderRoutes);
 app.use('/api/notifications', notificationRoutes);
+
+app.use('/api', tagRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/src/controllers/tagsController.js
+++ b/src/controllers/tagsController.js
@@ -1,0 +1,122 @@
+// src/controllers/tagsController.js
+const { distinct, eq, like, and, inArray } = require('drizzle-orm');
+const db = require('../configs/db'); // 引入 db 實例
+
+const { productsTable } = require('../models/productSchema');
+const { tagsTable } = require('../models/tagSchema');
+const { productTagSTable } = require('../models/productTagSchema');
+const { productImagesTable } = require('../models/productImageSchema'); // 引入 productImagesTable
+
+const getProductsWithCoverImages = async (productIds) => {
+  const products = await db
+    .select()
+    .from(productsTable)
+    .where(inArray(productsTable.id, productIds)); // 使用 inArray 篩選多個 ID
+
+  const productCoverImages = await db
+    .selectDistinctOn([productImagesTable.productId], {
+      productId: productImagesTable.productId,
+      coverImage: productImagesTable.imgUrl,
+    })
+    .from(productImagesTable)
+    .where(
+      and(inArray(productImagesTable.productId, productIds), eq(productImagesTable.isCover, true))
+    );
+
+  const productsWithCovers = products.map((product) => {
+    const coverImage = productCoverImages.find((img) => img.productId === product.id);
+    return {
+      ...product,
+      coverImage: coverImage ? coverImage.coverImage : null,
+    };
+  });
+
+  return productsWithCovers;
+};
+
+const getTagTypes = async (req, res) => {
+  try {
+    const ips = await db.selectDistinct({ value: tagsTable.ip }).from(tagsTable);
+    const brands = await db.selectDistinct({ value: tagsTable.brand }).from(tagsTable);
+    const series = await db.selectDistinct({ value: tagsTable.series }).from(tagsTable);
+
+    const uniqueIps = ips.map((item) => item.value).filter(Boolean);
+    const uniqueBrands = brands.map((item) => item.value).filter(Boolean);
+    const uniqueSeries = series.map((item) => item.value).filter(Boolean);
+
+    res.json({
+      ip: uniqueIps,
+      brand: uniqueBrands,
+      series: uniqueSeries,
+    });
+  } catch (error) {
+    console.error('獲取標籤類型時發生錯誤:', error);
+    res.status(500).json({ message: '內部伺服器錯誤', error: error.message });
+  }
+};
+
+const getProductsByTag = async (req, res) => {
+  const { type, value } = req.query;
+
+  if (!type || !value) {
+    console.log(`錯誤: 缺少 type 或 value 參數.`);
+    return res.status(400).json({ message: '請提供 type 和 value 參數' });
+  }
+
+  try {
+    let tagCondition;
+    switch (type) {
+      case 'ip':
+        tagCondition = eq(tagsTable.ip, value);
+        break;
+      case 'brand':
+        tagCondition = eq(tagsTable.brand, value);
+        break;
+      case 'series':
+        tagCondition = eq(tagsTable.series, value);
+        break;
+      default:
+        console.log(`錯誤: 無效的標籤類型 "${type}"`);
+        return res.status(400).json({ message: '無效的標籤類型，請提供 ip, brand 或 series' });
+    }
+
+    const matchingTags = await db
+      .select({ tagId: tagsTable.id })
+      .from(tagsTable)
+      .where(tagCondition);
+
+    const tagIds = matchingTags.map((t) => t.tagId);
+
+    if (tagIds.length === 0) {
+      console.log('沒有找到匹配的標籤。返回空商品列表。');
+      return res.json([]);
+    }
+
+    // 步驟 2: 從 product_tags 關聯表找出與這些 tagId 相關的 productId
+    const productIdsFromTags = await db
+      .select({ productId: productTagSTable.productId })
+      .from(productTagSTable)
+      .where(inArray(productTagSTable.tagId, tagIds));
+
+    const filteredProductIds = productIdsFromTags.map((p) => p.productId);
+
+    if (filteredProductIds.length === 0) {
+      console.log('沒有找到與標籤關聯的商品。返回空商品列表。');
+      return res.json([]);
+    }
+
+    const productsWithCovers = await getProductsWithCoverImages(filteredProductIds);
+
+    res.json(productsWithCovers);
+  } catch (error) {
+    console.error(`根據標籤查詢商品時發生錯誤 (type: ${type}, value: ${value}):`, error);
+    res.status(500).json({ message: '內部伺服器錯誤', error: error.message });
+  } finally {
+    console.log(`--- 請求處理結束 ---`);
+  }
+};
+
+module.exports = {
+  getTagTypes,
+  getProductsByTag,
+};

--- a/src/models/productTagSchema.js
+++ b/src/models/productTagSchema.js
@@ -1,0 +1,12 @@
+const { pgTable, serial, integer } = require('drizzle-orm/pg-core');
+
+const { tagsTable } = require('./tagSchema');
+const { productsTable } = require('./productsSchema');
+
+const productTagSTable = pgTable('product_tags', {
+  id: serial('id').primaryKey(),
+  tagId: integer('tag_id').references(() => tagsTable.id),
+  productId: integer('product_id').references(() => productsTable.id),
+});
+
+module.exports = { productTagSTable };

--- a/src/models/productTagSchema.js
+++ b/src/models/productTagSchema.js
@@ -1,7 +1,7 @@
 const { pgTable, serial, integer } = require('drizzle-orm/pg-core');
 
 const { tagsTable } = require('./tagSchema');
-const { productsTable } = require('./productsSchema');
+const { productsTable } = require('./productSchema');
 
 const productTagSTable = pgTable('product_tags', {
   id: serial('id').primaryKey(),

--- a/src/models/tagSchema.js
+++ b/src/models/tagSchema.js
@@ -1,0 +1,9 @@
+const { pgTable, serial, varchar } = require('drizzle-orm/pg-core');
+
+const tagsTable = pgTable('tagsTable', {
+  id: serial('id').primaryKey(),
+  ip: varchar('ip', { length: 225 }),
+  brand: varchar('brand', { length: 225 }),
+  series: varchar('series', { length: 225 }),
+});
+module.exports = { tagsTable };

--- a/src/routes/tagsRoutes.js
+++ b/src/routes/tagsRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+
+const router = express.Router();
+const { getTagTypes, getProductsByTag } = require('../controllers/tagsController');
+
+router.get('/tag-types', getTagTypes);
+
+router.get('/products-by-tag', getProductsByTag);
+
+module.exports = router;


### PR DESCRIPTION
### 變更內容
-讓前端點選某個標籤可以篩選商品


### 驗證方式



https://github.com/user-attachments/assets/413630b5-d777-4f2f-b24f-8bfb2805de39

###備註
都是get
影片中第一個api可以拿到資料庫中的 ip、brand 、series直接渲染在頁面上`http://localhost:3000/api/tag-types`
配合第二個api可以把值傳入篩選出想要的東西，第二個api `http://localhost:3000/api/products-by-tag?type=(這裡是傳入類型ip、brand、series給後端判斷)&value=(這個是你前面傳的類型裡面的內容)`
例如你前面類型是type=ip那後面就寫value=哥吉拉這樣  type=brand 那value= 品牌名稱以此類推

資料庫導入順序 product>productimage>tagstable>product_tags


tagstable、product_tags這兩個我放dc就不傳上來了


Close:#56