### PR TITLE
fix: token 驗證時帶入 user 以通過 isAdmin 權限驗證

### DIFF
--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -2,23 +2,25 @@ const db = require('../configs/db');
 const { productsTable } = require('../models/productSchema');
 const { productImagesTable } = require('../models/productImageSchema');
 const { inArray, eq, and, asc } = require('drizzle-orm');
+const isAdmin = require('../middleware/isAdmin');
 
 const getAllProducts = async (req, res) => {
-  const isAdmin = req.user?.role === 'admin';
+  const status = req.query.status;
+  const conditions = [eq(productsTable.isDeleted, false)];
+
+  if (!isAdmin) {
+    conditions.push(eq(productsTable.status, 'active'));
+  } else if (status && status !== 'all') {
+    conditions.push(eq(productsTable.status, status));
+  }
+
+  let query = db
+    .select()
+    .from(productsTable)
+    .where(and(...conditions))
+    .orderBy(productsTable.id);
+
   try {
-    const status = req.query.status;
-    let query = db.select().from(productsTable).orderBy(productsTable.id);
-
-    if (!isAdmin) {
-      query = query.where(
-        and(eq(productsTable.isDeleted, false), eq(productsTable.status, 'active'))
-      );
-    } else if (status && status !== 'all') {
-      query = query.where(
-        and(eq(productsTable.isDeleted, false), eq(productsTable.status, status))
-      );
-    }
-
     const products = await query;
 
     if (products.length === 0) return res.json([]);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -53,6 +53,7 @@ const login = async (req, res) => {
 
   try {
     const user = await db.select().from(usersTable).where(eq(usersTable.email, email)).limit(1);
+    console.log(user);
     if (user.length === 0) {
       return res.status(404).json({ error: 'Email未註冊' });
     }

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -53,7 +53,6 @@ const login = async (req, res) => {
 
   try {
     const user = await db.select().from(usersTable).where(eq(usersTable.email, email)).limit(1);
-    console.log(user);
     if (user.length === 0) {
       return res.status(404).json({ error: 'Email未註冊' });
     }

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,6 +1,9 @@
 const jwt = require('jsonwebtoken');
+const db = require('../configs/db');
+const { usersTable } = require('../models/userSchema');
+const { eq } = require('drizzle-orm');
 
-const authenticateToken = (req, res, next) => {
+const authenticateToken = async (req, res, next) => {
   const authHeader = req.headers['authorization'];
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ error: '未提供正確的 Authorization 標頭' });
@@ -8,13 +11,18 @@ const authenticateToken = (req, res, next) => {
 
   const token = authHeader.split(' ')[1];
 
-  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
-    if (err) {
-      return res.status(403).json({ error: 'Token 驗證失敗' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await db.select().from(usersTable).where(eq(usersTable.id, decoded.id)).limit(1);
+    if (user.length === 0) {
+      return res.status(401).json({ error: '使用者不存在' });
     }
-    req.user = user;
+
+    req.user = user[0];
     next();
-  });
+  } catch (err) {
+    return res.status(403).json({ error: 'Token 驗證失敗' });
+  }
 };
 
 module.exports = authenticateToken;

--- a/src/middleware/isAdmin.js
+++ b/src/middleware/isAdmin.js
@@ -1,5 +1,5 @@
 const isAdmin = (req, res, next) => {
-  if (!req.user || !req.user.isAdmin) {
+  if (!req.user || req.user.role !== 'admin') {
     return res.status(403).json({ error: '需要管理員權限' });
   }
   next();

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -7,18 +7,23 @@ const {
   updateProduct,
   deleteProduct,
 } = require('../controllers/productController');
-
+const authenticateToken = require('../middleware/auth');
 const isAdmin = require('../middleware/isAdmin');
 const validate = require('../middleware/validate');
 const { productSchema } = require('../validators/productValidator');
 
-router.get('/admin/products', isAdmin, getAllProducts);
-router.get('/admin/products/:id', isAdmin, getProductById);
-router.post('/admin/products', isAdmin, validate(productSchema), createProduct);
-router.put('/admin/products/:id', isAdmin, validate(productSchema), updateProduct);
-router.delete('/admin/products/:id', isAdmin, deleteProduct);
+router.get('/admin/products', authenticateToken, isAdmin, getAllProducts);
+router.get('/admin/products/:id', authenticateToken, isAdmin, getProductById);
+router.post('/admin/products', authenticateToken, isAdmin, validate(productSchema), createProduct);
+router.put(
+  '/admin/products/:id',
+  authenticateToken,
+  isAdmin,
+  validate(productSchema),
+  updateProduct
+);
+router.delete('/admin/products/:id', authenticateToken, isAdmin, deleteProduct);
 
 router.get('/products', getAllProducts);
 router.get('/products/:id', getProductById);
-
 module.exports = router;


### PR DESCRIPTION
- 優化 getAllProducts 寫法，拉出`[eq(productsTable.isDeleted, false)];`
- 優化 `auth.js`，role 如果有改動（admin 降級為 user)，可以抓到最新的 user 資料

測試方式：
- 先註冊 user，自行在資料庫將該user role 設定為 `'admin'`，看看是否能操作後台商品
- 請搭配前端 PR 使用 （尚未合併）

備註：
- API 路由的驗證邏輯是：是否有登入 (authenticateToken) -> 是否為 admin (isAdmin) -> 打API