### PR TITLE
feat: add PATCH notification read API

### DIFF
--- a/src/routes/notificationRoutes.js
+++ b/src/routes/notificationRoutes.js
@@ -44,4 +44,38 @@ router.post('/', authenticateToken, async (req, res) => {
   }
 });
 
+// 標記單筆通知為已讀 PATCH /api/notifications/:id/read
+router.patch('/:id/read', authenticateToken, async (req, res) => {
+  const id = Number(req.params.id);
+  if (isNaN(id)) return res.status(400).json({ error: '無效的ID' });
+
+  try {
+    // 查詢這筆通知
+    const [notification] = await db
+      .select()
+      .from(notificationsTable)
+      .where(eq(notificationsTable.id, id));
+
+    if (!notification) {
+      return res.status(404).json({ error: '找不到通知' });
+    }
+    // 驗證只能標記自己的通知
+    if (notification.userId !== req.user.id) {
+      return res.status(403).json({ error: '沒有權限標記此通知' });
+    }
+
+    // 更新為已讀
+    const [updatedNotification] = await db
+      .update(notificationsTable)
+      .set({ read: true })
+      .where(eq(notificationsTable.id, id))
+      .returning();
+
+    res.json(updatedNotification);
+  } catch (error) {
+    console.error('標記已讀失敗：', error);
+    res.status(500).json({ error: '伺服器錯誤，無法標記已讀' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
新增功能：PATCH 通知標記為已讀

功能說明：
- 新增 API：`PATCH /api/notifications/:id/read`
- 讓登入中的使用者可以將「自己的通知」標記為已讀
- 加入權限驗證（不能標記別人的通知）

測試方式 ：

切到我的分支22-feat/create-notification-api
驗證方式：
執行 npm i
執行 npm run migrate
執行 npm run dev

使用 Postman 測試：

註冊會員（POST）
http://localhost:3000/api/users/register
Body：
{
"username": "rose",
"email": "rose@example.com",
"password": "123"
}
登入會員（POST）
http://localhost:3000/api/users/login
Body：
{
"email": "rose@example.com",
"password": "123"
}
會拿到 JWT token

建立通知（POST）
http://localhost:3000/api/notifications
Headers：Authorization: Bearer <your_token>
Body：
{
"type": "order_created",
"message": "您有一筆訂單已成立！",
"orderId": 1234
}
查詢通知（GET）
http://localhost:3000/api/notifications
Headers：Authorization: Bearer <your_token>

成功會看到你剛剛建立的通知資料：

[
  {
    "id": 1,
    "userId": 3,
    "type": "order_created",
    "message": "您有一筆訂單已成立！",
    "orderId": 1234,
    "read": false,
    "createdAt": "2025-06-17T07:50:00.000Z"
  }
]

✅ 5. 標記通知為已讀（PATCH）
網址：http://localhost:3000/api/notifications/1/read
（請把 1 換成剛剛查到的通知 id）
方法：PATCH
Headers：

Authorization: Bearer <你的 token>
成功後read狀態變更為true：

{
  "id": 1,
  "read": true,
  ...
}

close #62 