### PR TITLE
fix: 修改tag標籤邏輯

### DIFF
--- a/scripts/check-tags.js
+++ b/scripts/check-tags.js
@@ -6,30 +6,22 @@ const { productTagSTable } = require('../src/models/productTagSchema');
 
 async function checkTags() {
   try {
-    console.log('🔍 檢查 tags 資料...');
-
     // 檢查所有 tags
     const allTags = await db.select().from(tagsTable);
-    console.log('📋 所有 tags:', allTags);
 
     // 檢查 series 類型的 tags
     const seriesTags = await db
       .select()
       .from(tagsTable)
       .where(eq(tagsTable.type, typeEnum.enumValues[2]));
-    console.log('🎬 Series tags:', seriesTags);
 
     // 檢查產品數量
     const products = await db.select().from(productsTable);
-    console.log('📦 產品數量:', products.length);
 
     // 檢查產品標籤關聯
     const productTags = await db.select().from(productTagSTable);
-    console.log('🏷️ 產品標籤關聯數量:', productTags.length);
 
     if (productTags.length > 0) {
-      console.log('🏷️ 產品標籤關聯範例:', productTags.slice(0, 5));
-
       // 檢查特定產品的標籤
       const firstProductId = productTags[0].productId;
       const productWithTags = await db
@@ -42,11 +34,9 @@ async function checkTags() {
         .from(productTagSTable)
         .leftJoin(tagsTable, eq(productTagSTable.tagId, tagsTable.id))
         .where(eq(productTagSTable.productId, firstProductId));
-
-      console.log('🔗 產品標籤關聯詳情:', productWithTags);
     }
   } catch (error) {
-    console.error('❌ 檢查失敗:', error);
+    console.error(' 檢查失敗:', error);
   } finally {
     process.exit(0);
   }

--- a/scripts/check-tags.js
+++ b/scripts/check-tags.js
@@ -1,0 +1,55 @@
+const { eq } = require('drizzle-orm');
+const db = require('../src/configs/db');
+const { tagsTable, typeEnum } = require('../src/models/tagsSchema');
+const { productsTable } = require('../src/models/productSchema');
+const { productTagSTable } = require('../src/models/productTagSchema');
+
+async function checkTags() {
+  try {
+    console.log('🔍 檢查 tags 資料...');
+
+    // 檢查所有 tags
+    const allTags = await db.select().from(tagsTable);
+    console.log('📋 所有 tags:', allTags);
+
+    // 檢查 series 類型的 tags
+    const seriesTags = await db
+      .select()
+      .from(tagsTable)
+      .where(eq(tagsTable.type, typeEnum.enumValues[2]));
+    console.log('🎬 Series tags:', seriesTags);
+
+    // 檢查產品數量
+    const products = await db.select().from(productsTable);
+    console.log('📦 產品數量:', products.length);
+
+    // 檢查產品標籤關聯
+    const productTags = await db.select().from(productTagSTable);
+    console.log('🏷️ 產品標籤關聯數量:', productTags.length);
+
+    if (productTags.length > 0) {
+      console.log('🏷️ 產品標籤關聯範例:', productTags.slice(0, 5));
+
+      // 檢查特定產品的標籤
+      const firstProductId = productTags[0].productId;
+      const productWithTags = await db
+        .select({
+          productId: productTagSTable.productId,
+          tagId: productTagSTable.tagId,
+          tagName: tagsTable.tagname,
+          tagType: tagsTable.type,
+        })
+        .from(productTagSTable)
+        .leftJoin(tagsTable, eq(productTagSTable.tagId, tagsTable.id))
+        .where(eq(productTagSTable.productId, firstProductId));
+
+      console.log('🔗 產品標籤關聯詳情:', productWithTags);
+    }
+  } catch (error) {
+    console.error('❌ 檢查失敗:', error);
+  } finally {
+    process.exit(0);
+  }
+}
+
+checkTags();

--- a/scripts/seed-tags.js
+++ b/scripts/seed-tags.js
@@ -1,0 +1,85 @@
+const { eq } = require('drizzle-orm');
+const db = require('../src/configs/db');
+const { tagsTable, typeEnum } = require('../src/models/tagsSchema');
+const { productsTable } = require('../src/models/productSchema');
+const { productTagSTable } = require('../models/productTagSchema');
+
+async function seedTags() {
+  try {
+    console.log('🌱 開始添加 tags 資料...');
+
+    // 檢查是否已有 tags
+    const existingTags = await db.select().from(tagsTable);
+    console.log('📋 現有 tags 數量:', existingTags.length);
+
+    if (existingTags.length === 0) {
+      // 添加一些基本的 series tags
+      const seriesTags = [
+        { tagname: '模型', type: typeEnum.enumValues[2] },
+        { tagname: '公仔', type: typeEnum.enumValues[2] },
+        { tagname: '立牌', type: typeEnum.enumValues[2] },
+        { tagname: '雕像', type: typeEnum.enumValues[2] },
+        { tagname: '抱枕', type: typeEnum.enumValues[2] },
+        { tagname: '徽章', type: typeEnum.enumValues[2] },
+        { tagname: '吊飾', type: typeEnum.enumValues[2] },
+        { tagname: 'T-shirt', type: typeEnum.enumValues[2] },
+      ];
+
+      const insertedTags = await db.insert(tagsTable).values(seriesTags).returning();
+      console.log(
+        '✅ 成功添加 tags:',
+        insertedTags.map((t) => t.tagname)
+      );
+    }
+
+    // 檢查產品數量
+    const products = await db.select().from(productsTable);
+    console.log('📦 產品數量:', products.length);
+
+    if (products.length > 0) {
+      // 檢查產品標籤關聯
+      const productTags = await db.select().from(productTagSTable);
+      console.log('🏷️ 現有產品標籤關聯數量:', productTags.length);
+
+      if (productTags.length === 0) {
+        // 獲取所有 tags
+        const allTags = await db.select().from(tagsTable);
+        console.log('🏷️ 所有 tags:', allTags);
+
+        // 為前幾個產品添加隨機標籤
+        const sampleProducts = products.slice(0, Math.min(5, products.length));
+        const sampleTags = allTags.slice(0, Math.min(3, allTags.length));
+
+        const productTagRelations = [];
+        for (const product of sampleProducts) {
+          // 為每個產品隨機分配 1-2 個標籤
+          const numTags = Math.floor(Math.random() * 2) + 1;
+          const selectedTags = sampleTags.slice(0, numTags);
+
+          for (const tag of selectedTags) {
+            productTagRelations.push({
+              productId: product.id,
+              tagId: tag.id,
+            });
+          }
+        }
+
+        if (productTagRelations.length > 0) {
+          const insertedRelations = await db
+            .insert(productTagSTable)
+            .values(productTagRelations)
+            .returning();
+          console.log('✅ 成功添加產品標籤關聯:', insertedRelations.length, '個');
+        }
+      }
+    }
+
+    console.log('🎉 Tags 資料添加完成！');
+  } catch (error) {
+    console.error('❌ 添加 tags 資料失敗:', error);
+  } finally {
+    process.exit(0);
+  }
+}
+
+seedTags();

--- a/scripts/seed-tags.js
+++ b/scripts/seed-tags.js
@@ -6,11 +6,7 @@ const { productTagSTable } = require('../models/productTagSchema');
 
 async function seedTags() {
   try {
-    console.log('🌱 開始添加 tags 資料...');
-
-    // 檢查是否已有 tags
     const existingTags = await db.select().from(tagsTable);
-    console.log('📋 現有 tags 數量:', existingTags.length);
 
     if (existingTags.length === 0) {
       // 添加一些基本的 series tags
@@ -26,25 +22,18 @@ async function seedTags() {
       ];
 
       const insertedTags = await db.insert(tagsTable).values(seriesTags).returning();
-      console.log(
-        '✅ 成功添加 tags:',
-        insertedTags.map((t) => t.tagname)
-      );
     }
 
     // 檢查產品數量
     const products = await db.select().from(productsTable);
-    console.log('📦 產品數量:', products.length);
 
     if (products.length > 0) {
       // 檢查產品標籤關聯
       const productTags = await db.select().from(productTagSTable);
-      console.log('🏷️ 現有產品標籤關聯數量:', productTags.length);
 
       if (productTags.length === 0) {
         // 獲取所有 tags
         const allTags = await db.select().from(tagsTable);
-        console.log('🏷️ 所有 tags:', allTags);
 
         // 為前幾個產品添加隨機標籤
         const sampleProducts = products.slice(0, Math.min(5, products.length));
@@ -69,14 +58,11 @@ async function seedTags() {
             .insert(productTagSTable)
             .values(productTagRelations)
             .returning();
-          console.log('✅ 成功添加產品標籤關聯:', insertedRelations.length, '個');
         }
       }
     }
-
-    console.log('🎉 Tags 資料添加完成！');
   } catch (error) {
-    console.error('❌ 添加 tags 資料失敗:', error);
+    console.error(' 添加 tags 資料失敗:', error);
   } finally {
     process.exit(0);
   }

--- a/src/controllers/tagsController.js
+++ b/src/controllers/tagsController.js
@@ -1,13 +1,13 @@
-const { eq, inArray, sql, and } = require('drizzle-orm');
+const { eq, inArray, sql, and, asc } = require('drizzle-orm');
 const { tagsTable, typeEnum } = require('../models/tagsSchema');
 const { productsTable, statusEnum } = require('../models/productSchema');
 const { productTagSTable } = require('../models/productTagSchema');
+const { productImagesTable } = require('../models/productImageSchema');
 const db = require('../configs/db');
 
 const tagsController = {
   getAllFilterTags: async (req, res) => {
     try {
-      // 獲取所有 'brand' 類型的標籤 (tagname 和 id)
       const brands = await db
         .select({
           id: tagsTable.id,
@@ -43,69 +43,60 @@ const tagsController = {
     const { tagname } = req.query;
 
     try {
-      let selectedTagNames = [];
-      let selectedTagIds = [];
-
-      if (tagname) {
-        selectedTagNames = tagname.split(',');
-
-        const tags = await db
-          .select({
-            id: tagsTable.id,
-            tagname: tagsTable.tagname,
-          })
-          .from(tagsTable)
-          .where(inArray(tagsTable.tagname, selectedTagNames))
-          .execute();
-
-        selectedTagIds = tags.map((tag) => tag.id);
-
-        if (selectedTagIds.length !== selectedTagNames.length) {
-          console.warn('Some provided tagnames did not match any existing tags.');
-        }
+      if (!tagname) {
+        return res.json({ products: [] });
       }
 
-      if (selectedTagIds.length === 0) {
-        const allActiveProducts = await db
-          .select()
-          .from(productsTable)
-          .where(eq(productsTable.status, statusEnum.enumValues[1]))
-          .execute();
-        return res.status(200).json({ products: allActiveProducts });
+      // Step 1: Find tag ID from tagname
+      const tags = await db
+        .select({ id: tagsTable.id })
+        .from(tagsTable)
+        .where(eq(tagsTable.tagname, tagname));
+      if (tags.length === 0) {
+        return res.json({ products: [] });
       }
+      const tagId = tags[0].id;
 
-      const productsWithMatchingTags = await db
-        .select({
-          productId: productTagSTable.productId,
-        })
+      // Step 2: Get product IDs for that tag
+      const productTagLinks = await db
+        .select({ productId: productTagSTable.productId })
         .from(productTagSTable)
-        .where(inArray(productTagSTable.tagId, selectedTagIds))
-        .groupBy(productTagSTable.productId)
-        .having((fields) => eq(sql`count(${fields.productId})`, selectedTagIds.length)) // 確保每個分組的 productId 數量等於選定標籤的總數
-        .execute();
-
-      const productIds = productsWithMatchingTags.map((p) => p.productId);
-
-      // 如果沒有找到任何符合所有標籤的產品
-      if (productIds.length === 0) {
-        return res.status(200).json({ products: [] });
+        .where(eq(productTagSTable.tagId, tagId));
+      if (productTagLinks.length === 0) {
+        return res.json({ products: [] });
       }
+      const productIds = productTagLinks.map((p) => p.productId);
 
-      // 根據篩選出的產品 ID 獲取產品詳細資訊，並且只顯示狀態為 'active' 的商品
+      // Step 3: Fetch 'active' products from the list of IDs
       const products = await db
         .select()
         .from(productsTable)
+        .where(and(inArray(productsTable.id, productIds), eq(productsTable.status, 'active')));
+      if (products.length === 0) {
+        return res.json({ products: [] });
+      }
+
+      // Step 4: Fetch cover images for these active products
+      const activeProductIds = products.map((p) => p.id);
+      const coverImages = await db
+        .select({ productId: productImagesTable.productId, imgUrl: productImagesTable.imgUrl })
+        .from(productImagesTable)
         .where(
           and(
-            inArray(productsTable.id, productIds), // 產品 ID 必須在篩選出的列表中
-            eq(productsTable.status, statusEnum.enumValues[1]) // 產品狀態必須是 'active'
+            inArray(productImagesTable.productId, activeProductIds),
+            eq(productImagesTable.isCover, true)
           )
-        )
-        .execute();
+        );
+      const coverMap = new Map(coverImages.map((img) => [img.productId, img.imgUrl]));
 
-      res.status(200).json({ products });
+      const productsWithCovers = products.map((p) => ({
+        ...p,
+        coverImage: coverMap.get(p.id) || null,
+      }));
+
+      res.json({ products: productsWithCovers });
     } catch (error) {
-      console.error('Error fetching products by tagnames:', error);
+      console.error('[API FATAL ERROR] in getProductsByTagnames:', error);
       res.status(500).json({ message: 'Internal server error' });
     }
   },

--- a/src/controllers/tagsController.js
+++ b/src/controllers/tagsController.js
@@ -1,6 +1,6 @@
-const { eq, inArray, sql, and, asc } = require('drizzle-orm');
+const { eq, inArray, and } = require('drizzle-orm');
 const { tagsTable, typeEnum } = require('../models/tagsSchema');
-const { productsTable, statusEnum } = require('../models/productSchema');
+const { productsTable } = require('../models/productSchema');
 const { productTagSTable } = require('../models/productTagSchema');
 const { productImagesTable } = require('../models/productImageSchema');
 const db = require('../configs/db');
@@ -47,7 +47,6 @@ const tagsController = {
         return res.json({ products: [] });
       }
 
-      // Step 1: Find tag ID from tagname
       const tags = await db
         .select({ id: tagsTable.id })
         .from(tagsTable)
@@ -57,7 +56,6 @@ const tagsController = {
       }
       const tagId = tags[0].id;
 
-      // Step 2: Get product IDs for that tag
       const productTagLinks = await db
         .select({ productId: productTagSTable.productId })
         .from(productTagSTable)
@@ -67,7 +65,6 @@ const tagsController = {
       }
       const productIds = productTagLinks.map((p) => p.productId);
 
-      // Step 3: Fetch 'active' products from the list of IDs
       const products = await db
         .select()
         .from(productsTable)
@@ -76,7 +73,6 @@ const tagsController = {
         return res.json({ products: [] });
       }
 
-      // Step 4: Fetch cover images for these active products
       const activeProductIds = products.map((p) => p.id);
       const coverImages = await db
         .select({ productId: productImagesTable.productId, imgUrl: productImagesTable.imgUrl })


### PR DESCRIPTION
### 變更內容
- tag標籤api

### 修改原因
- 把邏輯簡化直接用值去找tagid讓邏輯更清楚

### 驗證方式
跟之前的一樣但在拿到的東西會有一些差異性
{
        "products": [
            {
                "id": 101,
                "name": "某某鋼彈模型",
                "price": 1500,
                "status": "active",
                "coverImage": "https://your-image-url.com/gundam.jpg"
            },
            {
                "id": 105,
                "name": "另一款精緻模型",
                "price": 2200,
                "status": "active",
                "coverImage": "https://your-image-url.com/another-model.jpg"
            }
        ]
    }
`
可以直接拿到圖片可以解決有些圖片跑不出來的問題
Close:#76