### PR TITLE
feat: 修改 stockLog schema 欄位，新增 stockLog API

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const notificationRoutes = require('./src/routes/notificationRoutes');
 const cartRoutes = require('./src/routes/cartRoutes');
 const userOrderRoutes = require('./src/routes/userOrderRoutes');
 const tagsRoutes = require('./src/routes/tagRoutes');
+const stockLogRoutes = require('./src/routes/stockLogRoutes');
 const authRoutes = require('./src/routes/authRoutes');
 const aiRoutes = require('./src/routes/aiRoutes');
 
@@ -34,6 +35,7 @@ app.use('/api', orderRoutes);
 app.use('/api/ai', aiRoutes);
 app.use('/api/user', userOrderRoutes);
 app.use('/api', adminOrderRoutes);
+app.use('/api', stockLogRoutes);
 
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, '0.0.0.0', () => {

--- a/src/controllers/stockLogController.js
+++ b/src/controllers/stockLogController.js
@@ -1,0 +1,89 @@
+const db = require('../configs/db');
+const { stockLogsTable } = require('../models/stockLogSchema');
+const { productsTable } = require('../models/productSchema');
+const { eq } = require('drizzle-orm');
+
+const getAllStockLogs = async (req, res) => {
+  try {
+    const stockLogs = await db.select().from(stockLogsTable).orderBy(stockLogsTable.id);
+    res.json(stockLogs);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+const getStockLogsByProduct = async (req, res) => {
+  const productId = Number(req.params.id);
+  try {
+    const stockLogs = await db
+      .select()
+      .from(stockLogsTable)
+      .where(eq(stockLogsTable.productId, productId));
+    res.json(stockLogs);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+const getStockLogById = async (req, res) => {
+  const stockLogId = Number(req.params.id);
+  try {
+    const stockLog = await db
+      .select()
+      .from(stockLogsTable)
+      .where(eq(stockLogsTable.id, stockLogId));
+    res.json(stockLog);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+const createStockLog = async (req, res) => {
+  const productId = Number(req.params.id);
+  const { amountChange, reason } = req.body;
+  const email = req.user.email;
+
+  try {
+    const product = await db
+      .select()
+      .from(productsTable)
+      .where(eq(productsTable.id, productId))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    if (!product || product.isDeleted) {
+      return res.status(404).json({ error: '找不到商品' });
+    }
+    const newStock = product.stockOnHand + amountChange;
+    if (newStock < 0) return res.status(400).json({ error: '庫存不得小於零' });
+
+    const newStockLog = await db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(stockLogsTable)
+        .values({
+          productId,
+          amountAfter: newStock,
+          amountChange,
+          reason,
+          email,
+        })
+        .returning();
+
+      await tx
+        .update(productsTable)
+        .set({ stockOnHand: newStock })
+        .where(eq(productsTable.id, productId));
+      return inserted[0];
+    });
+    res.status(201).json({ newStockLog });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+module.exports = {
+  getAllStockLogs,
+  getStockLogsByProduct,
+  getStockLogById,
+  createStockLog,
+};

--- a/src/models/stockLogSchema.js
+++ b/src/models/stockLogSchema.js
@@ -1,12 +1,13 @@
 const { pgTable, pgEnum, serial, integer, varchar, timestamp } = require('drizzle-orm/pg-core');
 const { productsTable } = require('./productSchema');
-
+const { usersTable } = require('./userSchema');
 const stockReasonEnum = pgEnum('stock_reason', [
   'stock_in',
   'stock_out',
   'adjustment',
   'initial',
   'return',
+  'correction',
 ]);
 
 const stockLogsTable = pgTable('stock_logs', {
@@ -14,12 +15,14 @@ const stockLogsTable = pgTable('stock_logs', {
   productId: integer('product_id')
     .notNull()
     .references(() => productsTable.id),
-  amountBefore: integer('amount_before').notNull(),
   amountAfter: integer('amount_after').notNull(),
   amountChange: integer('amount_change').notNull(),
   reason: stockReasonEnum('reason').default('adjustment'),
-  role: varchar('role', { length: 100 }),
+  email: varchar('email')
+    .notNull()
+    .references(() => usersTable.email),
   createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });
 
 module.exports = {

--- a/src/models/stockLogSchema.js
+++ b/src/models/stockLogSchema.js
@@ -22,7 +22,6 @@ const stockLogsTable = pgTable('stock_logs', {
     .notNull()
     .references(() => usersTable.email),
   createdAt: timestamp('created_at').defaultNow(),
-  updatedAt: timestamp('updated_at').defaultNow(),
 });
 
 module.exports = {

--- a/src/routes/stockLogRoutes.js
+++ b/src/routes/stockLogRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getAllStockLogs,
+  getStockLogsByProduct,
+  getStockLogById,
+  createStockLog,
+} = require('../controllers/stockLogController');
+
+const authenticateToken = require('../middleware/auth');
+const isAdmin = require('../middleware/isAdmin');
+
+router.get('/admin/stocklogs', authenticateToken, isAdmin, getAllStockLogs);
+router.get('/admin/products/:id/stocklogs', authenticateToken, isAdmin, getStockLogsByProduct);
+router.get('/admin/stocklogs/:id', authenticateToken, isAdmin, getStockLogById);
+router.post('/admin/products/:id/stocklogs', authenticateToken, isAdmin, createStockLog);
+
+module.exports = router;


### PR DESCRIPTION
- 庫存歷史紀錄 reason 類型多加一個 correction，用來取代 update 的功能，若不慎誤植庫存更動數量，只能多加一筆 correct 回來，因為歷史紀錄不應該允許更新
- 因為 users 表應該允許多位 admin，庫存紀錄角色欄位應該改成紀錄 email 帳號
- 已更新 supabase 資料表欄位
- `tansaction`表示 all or none 的操作，包在裡面的事情要不全部完成，要不都不做，避免庫存資料對不起來
- API 有三種 get ：
  - 拿全部庫存紀錄
  - 拿單一庫存紀錄
  - 拿某商品的庫存紀錄 

用 postman 測試，先 post 幾筆不同商品的庫存異動，再測試查看庫存

<img width="1053" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/df16dd51-690c-4fb3-93e2-ebcfffd321f2" />
<img width="1037" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/6230b5d9-ad9a-4a20-a0a6-f3af5716a58a" />
<img width="1034" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/361181a8-7357-4e73-aa24-98953d93854e" />
<img width="1027" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/f9c687c7-e51d-4f0b-86bb-a5d611f4b8aa" />
