### PR TITLE
feat: 新增隨機推薦商品 API (/products/random)

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const userOrderRoutes = require('./src/routes/userOrderRoutes');
 const tagsRoutes = require('./src/routes/tagRoutes');
 const authRoutes = require('./src/routes/authRoutes');
 const aiRoutes = require('./src/routes/aiRoutes');
+const productRecommendRoutes = require('./src/routes/productRecommendRoutes');
 
 const favoriteRoutes = require('./src/routes/favoriteRoutes');
 
@@ -23,6 +24,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use(cors());
 
 app.use('/api/auth', authRoutes);
+app.use('/api', productRecommendRoutes);
 app.use('/api', productRoutes);
 app.use('/api', ecpayRoutes);
 app.use('/api/notifications', notificationRoutes);

--- a/src/controllers/productRecommendController.js
+++ b/src/controllers/productRecommendController.js
@@ -1,0 +1,50 @@
+const db = require('../configs/db');
+const { productsTable } = require('../models/productSchema');
+const { productImagesTable } = require('../models/productImageSchema');
+const { inArray, eq, and } = require('drizzle-orm');
+const { sql } = require('drizzle-orm');
+
+const getRandomProducts = async (req, res) => {
+  const limit = Math.min(Number(req.query.limit) || 4, 20);
+
+  try {
+    const products = await db
+      .select()
+      .from(productsTable)
+      .where(and(eq(productsTable.isDeleted, false), eq(productsTable.status, 'active')))
+      .orderBy(sql`RANDOM()`)
+      .limit(limit);
+
+    if (products.length === 0) return res.json([]);
+
+    const productIds = products.map((p) => p.id);
+
+    const coverImages = await db
+      .select({
+        productId: productImagesTable.productId,
+        imgUrl: productImagesTable.imgUrl,
+      })
+      .from(productImagesTable)
+      .where(
+        and(inArray(productImagesTable.productId, productIds), eq(productImagesTable.isCover, true))
+      );
+
+    const coverMap = new Map();
+    for (const img of coverImages) {
+      coverMap.set(img.productId, img.imgUrl);
+    }
+
+    const productsWithCovers = products.map((p) => ({
+      ...p,
+      coverImage: coverMap.get(p.id) || null,
+    }));
+
+    res.json(productsWithCovers);
+  } catch (err) {
+    res.status(500).json({ error: '取得隨機商品失敗', detail: err.message });
+  }
+};
+
+module.exports = {
+  getRandomProducts,
+};

--- a/src/routes/productRecommendRoutes.js
+++ b/src/routes/productRecommendRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { getRandomProducts } = require('../controllers/productRecommendController');
+
+router.get('/products/random', getRandomProducts);
+
+module.exports = router;


### PR DESCRIPTION
## 內容：
- 新增 GET `/api/products/random` API
- 隨機推薦最多 N 筆商品（預設 4、上限 20）
- 每筆資料包含封面圖欄位 `coverImage`

## 功能確認：
-  篩選上架且未刪除的商品
- 支援 query 參數 `limit`
-  使用 SQL 隨機排序
-  回傳封面圖

## 測試方式 : 直接在瀏覽器上打http://localhost:3000/api/products/random 
可打到資料即代表OK
![image](https://github.com/user-attachments/assets/97027441-b6d8-47b5-9db9-bfb6d0670de9)
