### PR TITLE
先不合 fix:  全站加入 cache 讓商品頁不用每次都載入很久

### DIFF
--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -4,7 +4,7 @@ const { productImagesTable } = require('../models/productImageSchema');
 const { favoritesTable } = require('../models/favoriteSchema');
 const jwt = require('jsonwebtoken');
 
-const { inArray, eq, and, asc, count } = require('drizzle-orm');
+const { eq, and, asc, count } = require('drizzle-orm');
 const { deleteProductImages } = require('../services/productImageService');
 const { uploadProductImage } = require('../controllers/productImageController');
 
@@ -34,16 +34,33 @@ const getAllProducts = async (req, res) => {
     const totalCount = totalResult.count;
     const totalPages = Math.ceil(totalCount / limit);
 
-    let query = db
-      .select()
+    const products = await db
+      .select({
+        id: productsTable.id,
+        name: productsTable.name,
+        sku: productsTable.sku,
+        description: productsTable.description,
+        price: productsTable.price,
+        status: productsTable.status,
+        stockOnHand: productsTable.stockOnHand,
+        stockReserved: productsTable.stockReserved,
+        createdAt: productsTable.createdAt,
+        updatedAt: productsTable.updatedAt,
+        coverImage: productImagesTable.imgUrl,
+      })
       .from(productsTable)
+      .leftJoin(
+        productImagesTable,
+        and(
+          eq(productsTable.id, productImagesTable.productId),
+          eq(productImagesTable.isCover, true)
+        )
+      )
       .where(baseCondition)
       .orderBy(productsTable.id)
       .limit(limit)
       .offset(offset);
 
-    const products = await query;
-    
     if (products.length === 0) {
       return res.json({
         data: [],
@@ -53,43 +70,21 @@ const getAllProducts = async (req, res) => {
           totalCount,
           limit,
           hasNextPage: false,
-          hasPreviousPage: false
-        }
+          hasPreviousPage: false,
+        },
       });
     }
 
-    const productIds = products.map((p) => p.id);
-
-    const coverImages = await db
-      .select({
-        productId: productImagesTable.productId,
-        imgUrl: productImagesTable.imgUrl,
-      })
-      .from(productImagesTable)
-      .where(
-        and(inArray(productImagesTable.productId, productIds), eq(productImagesTable.isCover, true))
-      );
-
-    const coverMap = new Map();
-    for (const img of coverImages) {
-      coverMap.set(img.productId, img.imgUrl);
-    }
-
-    const productsWithCovers = products.map((p) => ({
-      ...p,
-      coverImage: coverMap.get(p.id) || null,
-    }));
-
     res.json({
-      data: productsWithCovers,
+      data: products,
       pagination: {
         currentPage: page,
         totalPages,
         totalCount,
         limit,
         hasNextPage: page < totalPages,
-        hasPreviousPage: page > 1
-      }
+        hasPreviousPage: page > 1,
+      },
     });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -4,7 +4,7 @@ const { productImagesTable } = require('../models/productImageSchema');
 const { favoritesTable } = require('../models/favoriteSchema');
 const jwt = require('jsonwebtoken');
 
-const { inArray, eq, and, asc } = require('drizzle-orm');
+const { inArray, eq, and, asc, count } = require('drizzle-orm');
 const { deleteProductImages } = require('../services/productImageService');
 const { uploadProductImage } = require('../controllers/productImageController');
 
@@ -13,22 +13,50 @@ const getAllProducts = async (req, res) => {
 
   try {
     const status = req.query.status;
-    let query = db.select().from(productsTable).orderBy(productsTable.id);
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 20;
+    const offset = (page - 1) * limit;
 
+    let baseCondition;
     if (!isAdmin) {
-      query = query.where(
-        and(eq(productsTable.isDeleted, false), eq(productsTable.status, 'active'))
-      );
+      baseCondition = and(eq(productsTable.isDeleted, false), eq(productsTable.status, 'active'));
     } else if (status && status !== 'all') {
-      query = query.where(
-        and(eq(productsTable.isDeleted, false), eq(productsTable.status, status))
-      );
+      baseCondition = and(eq(productsTable.isDeleted, false), eq(productsTable.status, status));
     } else if (isAdmin) {
-      query = query.where(eq(productsTable.isDeleted, false));
+      baseCondition = eq(productsTable.isDeleted, false);
     }
 
+    const [totalResult] = await db
+      .select({ count: count() })
+      .from(productsTable)
+      .where(baseCondition);
+
+    const totalCount = totalResult.count;
+    const totalPages = Math.ceil(totalCount / limit);
+
+    let query = db
+      .select()
+      .from(productsTable)
+      .where(baseCondition)
+      .orderBy(productsTable.id)
+      .limit(limit)
+      .offset(offset);
+
     const products = await query;
-    if (products.length === 0) return res.json([]);
+    
+    if (products.length === 0) {
+      return res.json({
+        data: [],
+        pagination: {
+          currentPage: page,
+          totalPages,
+          totalCount,
+          limit,
+          hasNextPage: false,
+          hasPreviousPage: false
+        }
+      });
+    }
 
     const productIds = products.map((p) => p.id);
 
@@ -52,7 +80,17 @@ const getAllProducts = async (req, res) => {
       coverImage: coverMap.get(p.id) || null,
     }));
 
-    res.json(productsWithCovers);
+    res.json({
+      data: productsWithCovers,
+      pagination: {
+        currentPage: page,
+        totalPages,
+        totalCount,
+        limit,
+        hasNextPage: page < totalPages,
+        hasPreviousPage: page > 1
+      }
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/src/controllers/tagController.js
+++ b/src/controllers/tagController.js
@@ -79,8 +79,7 @@ const tagsController = {
         );
 
       res.json({ products });
-    } catch (error) {
-      console.error('Error in getProductsByTagnames:', error);
+    } catch {
       res.status(500).json({ message: 'Internal server error' });
     }
   },

--- a/src/controllers/tagController.js
+++ b/src/controllers/tagController.js
@@ -1,4 +1,4 @@
-const { eq, inArray, and } = require('drizzle-orm');
+const { eq, and } = require('drizzle-orm');
 const { tagsTable, typeEnum } = require('../models/tagSchema');
 const { productsTable } = require('../models/productSchema');
 const { productTagSTable } = require('../models/productTagSchema');
@@ -46,51 +46,41 @@ const tagsController = {
         return res.json({ products: [] });
       }
 
-      const tags = await db
-        .select({ id: tagsTable.id })
-        .from(tagsTable)
-        .where(eq(tagsTable.tagname, tagname));
-      if (tags.length === 0) {
-        return res.json({ products: [] });
-      }
-      const tagId = tags[0].id;
-
-      const productTagLinks = await db
-        .select({ productId: productTagSTable.productId })
-        .from(productTagSTable)
-        .where(eq(productTagSTable.tagId, tagId));
-      if (productTagLinks.length === 0) {
-        return res.json({ products: [] });
-      }
-      const productIds = productTagLinks.map((p) => p.productId);
-
       const products = await db
-        .select()
+        .select({
+          id: productsTable.id,
+          name: productsTable.name,
+          sku: productsTable.sku,
+          description: productsTable.description,
+          price: productsTable.price,
+          status: productsTable.status,
+          stockOnHand: productsTable.stockOnHand,
+          stockReserved: productsTable.stockReserved,
+          createdAt: productsTable.createdAt,
+          updatedAt: productsTable.updatedAt,
+          coverImage: productImagesTable.imgUrl,
+        })
         .from(productsTable)
-        .where(and(inArray(productsTable.id, productIds), eq(productsTable.status, 'active')));
-      if (products.length === 0) {
-        return res.json({ products: [] });
-      }
-
-      const activeProductIds = products.map((p) => p.id);
-      const coverImages = await db
-        .select({ productId: productImagesTable.productId, imgUrl: productImagesTable.imgUrl })
-        .from(productImagesTable)
-        .where(
+        .innerJoin(productTagSTable, eq(productsTable.id, productTagSTable.productId))
+        .innerJoin(tagsTable, eq(productTagSTable.tagId, tagsTable.id))
+        .leftJoin(
+          productImagesTable,
           and(
-            inArray(productImagesTable.productId, activeProductIds),
+            eq(productsTable.id, productImagesTable.productId),
             eq(productImagesTable.isCover, true)
           )
+        )
+        .where(
+          and(
+            eq(tagsTable.tagname, tagname),
+            eq(productsTable.status, 'active'),
+            eq(productsTable.isDeleted, false)
+          )
         );
-      const coverMap = new Map(coverImages.map((img) => [img.productId, img.imgUrl]));
 
-      const productsWithCovers = products.map((p) => ({
-        ...p,
-        coverImage: coverMap.get(p.id) || null,
-      }));
-
-      res.json({ products: productsWithCovers });
-    } catch {
+      res.json({ products });
+    } catch (error) {
+      console.error('Error in getProductsByTagnames:', error);
       res.status(500).json({ message: 'Internal server error' });
     }
   },


### PR DESCRIPTION
### 變更內容
- 新增全站快取，快取保留十分鐘。包含單一商品頁面和 tag 點擊後的頁面
- 後台商品列表跟庫存列表一次載入 20筆，不會載很久

### 修改原因
- 提升商品頁使用者體驗，讓用戶不用一直等待載入商品
- 後台也不用等 loading 很久

### 驗證方式
1. `npm run dev` 開啟本地伺服器
2. 前端切往同分支
3. 確認載入商品跟返回都很快速 💨